### PR TITLE
live reload for proxy using browsersync

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -12,12 +12,14 @@
         "proxy": "aem-site-theme-builder live",
         "proxy:wait": "sleep 1 && npm run proxy",
         "prod": "webpack -p --config ./webpack.prod.js",
-        "deploy": "aem-site-theme-builder deploy"
+        "deploy": "aem-site-theme-builder deploy",
+        "browsersync": "browser-sync start --proxy 'localhost:%AEM_SITE_PROXY_PORT%' --files 'dist'"
     },
     "devDependencies": {
         "@adobe/aem-site-theme-builder": "1.0.0",
         "autoprefixer": "^9.2.1",
         "bestzip": "^2.1.6",
+        "browser-sync": "^2.26.13",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^5.0.4",
         "cross-var": "^1.1.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -11,7 +11,7 @@
         "live": "npm-run-all -p dev-watch proxy browsersync",
         "proxy": "aem-site-theme-builder live",
         "prod": "webpack -p --config ./webpack.prod.js",
-        "browsersync": "browser-sync start --proxy 'localhost:%AEM_SITE_PROXY_PORT%' --files 'dist'"
+        "browsersync": "browser-sync start --proxy 'localhost:7000' --files 'dist'"
     },
     "devDependencies": {
         "@adobe/aem-site-theme-builder": "1.0.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -8,11 +8,9 @@
     "scripts": {
         "dev": "webpack -d --env dev --config ./webpack.dev.js",
         "dev-watch": "watch 'npm run dev' src",
-        "live": "npm-run-all -p dev-watch proxy:wait",
+        "live": "npm-run-all -p dev-watch proxy browsersync",
         "proxy": "aem-site-theme-builder live",
-        "proxy:wait": "sleep 1 && npm run proxy",
         "prod": "webpack -p --config ./webpack.prod.js",
-        "deploy": "aem-site-theme-builder deploy",
         "browsersync": "browser-sync start --proxy 'localhost:%AEM_SITE_PROXY_PORT%' --files 'dist'"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description

PR provides functionality of reloading browser tab after any change in `dist` folder while using live preview and proxy solution.

Browsersync is used as a solution for watching changes and reloading browser tab. It runs in a proxy mode and creates additional localhost server at port 3000.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
