### PR TITLE
Additional npm compile script to avoid usage of global webpack on win…

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -7,7 +7,8 @@
     "license": "MIT License, Copyright 2020 Adobe Systems Incorporated",
     "scripts": {
         "build": "webpack -p --config ./webpack.prod.js",
-        "live": "watch 'webpack -d --env dev --config ./webpack.dev.js' src & aem-site-theme-builder live & browser-sync start --proxy 'localhost:7000' --files 'dist'"
+        "compile": "webpack -d --env dev --config ./webpack.dev.js",
+        "live": "watch 'npm run compile' src & aem-site-theme-builder live & browser-sync start --proxy 'localhost:7000' --files 'dist'"
     },
     "devDependencies": {
         "@adobe/aem-site-theme-builder": "4.0.1",


### PR DESCRIPTION
Bugfix for Windows users. Additional npm script has to be provided so Windows will not try to use global webpack and force it to use locally installed one.