### PR TITLE
Fixed npm run deploy, deploy with static template name for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT License, Copyright 2020 Adobe Systems Incorporated",
   "scripts": {
     "build": "aem-site-template-builder",
-    "deploy": "echo \"-F file=@`node -p -e \"p=require('./package.json'); p.name+'-'+p.version+'.zip'\"`\" | xargs curl -u admin:admin http://localhost:4502/conf/global/site-templates.import.html",
-    "deploy-static": "curl -u admin:admin -F 'file=@aem-site-template-basic-4.0.2.zip' http://localhost:4502/conf/global/site-templates.import.html"
+    "deploy": "curl -u admin:admin -F 'file=@aem-site-template-basic-latest.zip' http://localhost:4502/conf/global/site-templates.import.html"
   },
   "devDependencies": {
     "@adobe/aem-site-template-builder": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy": "curl -u admin:admin -F 'file=@aem-site-template-basic-latest.zip' http://localhost:4502/conf/global/site-templates.import.html"
   },
   "devDependencies": {
-    "@adobe/aem-site-template-builder": "2.0.0"
+    "@adobe/aem-site-template-builder": "2.0.1"
   },
   "siteTemplate": {
     "title": "Basic AEM Site Template",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT License, Copyright 2020 Adobe Systems Incorporated",
   "scripts": {
     "build": "aem-site-template-builder",
-    "deploy": "SITE_TEMPLATE_ZIP=\"$(node -p -e \"require('./package.json').name\")-$(node -p -e \"require('./package.json').version\").zip\" && curl -u admin:admin -F file=$SITE_TEMPLATE_ZIP http://localhost:4502/conf/global/site-templates.import.html"
+    "deploy": "echo \"-F file=@`node -p -e \"p=require('./package.json'); p.name+'-'+p.version+'.zip'\"`\" | xargs curl -u admin:admin http://localhost:4502/conf/global/site-templates.import.html",
+    "deploy-static": "curl -u admin:admin -F 'file=@aem-site-template-basic-4.0.2.zip' http://localhost:4502/conf/global/site-templates.import.html"
   },
   "devDependencies": {
     "@adobe/aem-site-template-builder": "2.0.0"


### PR DESCRIPTION
Fix for `npm run deploy` script. New approach assumes there is always `<name>-latest.zip` file produced by template builder which npm deploy script to use it statically without need to generate dynamic name which was very problematic on windows devices. 

New version of [template builder](https://github.com/adobe/aem-site-template-builder) has to be released first and included into site template before merging this PR.