### PR TITLE
Bugfix/windows does not recognize webpack command

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -8,7 +8,10 @@
     "scripts": {
         "build": "webpack -p --config ./webpack.prod.js",
         "compile": "webpack -d --env dev --config ./webpack.dev.js",
-        "live": "watch 'npm run compile' src & aem-site-theme-builder live & browser-sync start --proxy 'localhost:7000' --files 'dist'"
+        "browser-sync": "browser-sync start --proxy 'localhost:7000' --files 'dist'",
+        "proxy": "aem-site-theme-builder live",
+        "watch": "watch \"npm run compile\" src",
+        "live": "npm-run-all -p watch proxy browser-sync"
     },
     "devDependencies": {
         "@adobe/aem-site-theme-builder": "4.0.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -7,7 +7,8 @@
     "license": "MIT License, Copyright 2020 Adobe Systems Incorporated",
     "scripts": {
         "build": "webpack -p --config ./webpack.prod.js",
-        "live": "watch 'webpack -d --env dev --config ./webpack.dev.js' src & aem-site-theme-builder live & browser-sync start --proxy 'localhost:7000' --files 'dist'"
+        "compile": "webpack -d --env dev --config ./webpack.dev.js",
+        "live": "watch 'npm run compile' src & aem-site-theme-builder live & browser-sync start --proxy 'localhost:7000' --files 'dist'"
     },
     "devDependencies": {
         "@adobe/aem-site-theme-builder": "4.0.1",


### PR DESCRIPTION
Due to Windows limitation in way of handling parallel scripts it is required to spread functionalities to separate npm scripts and run them using `npm-run-all` in `--parallel` mode.