### PR TITLE
template builder v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy": "curl -u admin:admin -F file=@aem-site-template-basic-latest.zip http://localhost:4502/conf/global/site-templates.import.html"
   },
   "devDependencies": {
-    "@adobe/aem-site-template-builder": "2.1.2"
+    "@adobe/aem-site-template-builder": "2.2.0"
   },
   "siteTemplate": {
     "title": "Basic AEM Site Template",


### PR DESCRIPTION
Bump version of [AEM Site Template Builder](https://github.com/adobe/aem-site-template-builder) to version [2.2.0](https://github.com/adobe/aem-site-template-builder/releases/tag/v2.2.0).

Site Template is no longer required to be a git repo for Template Builder to build it.